### PR TITLE
Allow replacing Exit function

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Note: Syslog hook also support connecting to local syslog (Ex. "/dev/log" or "/v
 | [ElasticSearch](https://github.com/sohlich/elogrus) | Hook for logging to ElasticSearch|
 | [Sumorus](https://github.com/doublefree/sumorus) | Hook for logging to [SumoLogic](https://www.sumologic.com/)|
 | [Logstash](https://github.com/bshuster-repo/logrus-logstash-hook) | Hook for logging to [Logstash](https://www.elastic.co/products/logstash) |
+| [Logmatic.io](https://github.com/logmatic/logmatic-go) | Hook for logging to [Logmatic.io](http://logmatic.io/) |
+
 
 #### Level logging
 

--- a/README.md
+++ b/README.md
@@ -400,3 +400,20 @@ handler := func() {
 logrus.RegisterExitHandler(handler)
 ...
 ```
+
+#### Thread safty
+
+By default Logger is protected by mutex for concurrent writes, this mutex is invoked when calling hooks and writing logs.
+If you are sure such locking is not needed, you can call logger.SetNoLock() to disable the locking.
+
+Situation when locking is not needed includes:
+
+* You have no hooks registered, or hooks calling is already thread-safe.
+
+* Writing to logger.Out is already thread-safe, for example:
+
+  1) logger.Out is protected by locks.
+
+  2) logger.Out is a os.File handler opened with `O_APPEND` flag, and every write is smaller than 4k. (This allow multi-thread/multi-process writing)
+
+     (Refer to http://www.notthewizard.com/2014/06/17/are-files-appends-really-atomic/)

--- a/alt_exit.go
+++ b/alt_exit.go
@@ -51,6 +51,16 @@ func Exit(code int) {
 	os.Exit(code)
 }
 
+// handleExit runs all the Logrus atexit handlers and then terminates the program using the logger's Exit function (or os.Exit() if no exit function is set).
+func (logger *Logger) handleExit(code int) {
+	runHandlers()
+	if logger.Exit != nil {
+		logger.Exit(code)
+	} else {
+		os.Exit(code)
+	}
+}
+
 // RegisterExitHandler adds a Logrus Exit handler, call logrus.Exit to invoke
 // all handlers. The handlers will also be invoked when any Fatal log entry is
 // made.

--- a/entry.go
+++ b/entry.go
@@ -3,10 +3,20 @@ package logrus
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
+	"sync"
 	"time"
 )
+
+var bufferPool *sync.Pool
+
+func init() {
+	bufferPool = &sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+}
 
 // Defines the key when adding errors using WithError.
 var ErrorKey = "error"
@@ -29,6 +39,9 @@ type Entry struct {
 
 	// Message passed to Debug, Info, Warn, Error, Fatal or Panic
 	Message string
+
+	// When formatter is called in entry.log(), an Buffer may be set to entry
+	Buffer *bytes.Buffer
 }
 
 func NewEntry(logger *Logger) *Entry {
@@ -39,21 +52,15 @@ func NewEntry(logger *Logger) *Entry {
 	}
 }
 
-// Returns a reader for the entry, which is a proxy to the formatter.
-func (entry *Entry) Reader() (*bytes.Buffer, error) {
-	serialized, err := entry.Logger.Formatter.Format(entry)
-	return bytes.NewBuffer(serialized), err
-}
-
 // Returns the string representation from the reader and ultimately the
 // formatter.
 func (entry *Entry) String() (string, error) {
-	reader, err := entry.Reader()
+	serialized, err := entry.Logger.Formatter.Format(entry)
 	if err != nil {
 		return "", err
 	}
-
-	return reader.String(), err
+	str := string(serialized)
+	return str, nil
 }
 
 // Add an error as single field (using the key defined in ErrorKey) to the Entry.
@@ -81,6 +88,7 @@ func (entry *Entry) WithFields(fields Fields) *Entry {
 // This function is not declared with a pointer value because otherwise
 // race conditions will occur when using multiple goroutines
 func (entry Entry) log(level Level, msg string) {
+	var buffer *bytes.Buffer
 	entry.Time = time.Now()
 	entry.Level = level
 	entry.Message = msg
@@ -90,20 +98,23 @@ func (entry Entry) log(level Level, msg string) {
 		fmt.Fprintf(os.Stderr, "Failed to fire hook: %v\n", err)
 		entry.Logger.mu.Unlock()
 	}
-
-	reader, err := entry.Reader()
+	buffer = bufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	defer bufferPool.Put(buffer)
+	entry.Buffer = buffer
+	serialized, err := entry.Logger.Formatter.Format(&entry)
+	entry.Buffer = nil
 	if err != nil {
 		entry.Logger.mu.Lock()
 		fmt.Fprintf(os.Stderr, "Failed to obtain reader, %v\n", err)
 		entry.Logger.mu.Unlock()
-	}
-
-	entry.Logger.mu.Lock()
-	defer entry.Logger.mu.Unlock()
-
-	_, err = io.Copy(entry.Logger.Out, reader)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
+	} else {
+		entry.Logger.mu.Lock()
+		_, err = entry.Logger.Out.Write(serialized)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to write to log, %v\n", err)
+		}
+		entry.Logger.mu.Unlock()
 	}
 
 	// To avoid Entry#log() returning a value that only would make sense for

--- a/entry.go
+++ b/entry.go
@@ -161,7 +161,7 @@ func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.log(FatalLevel, fmt.Sprint(args...))
 	}
-	Exit(1)
+	entry.Logger.handleExit(1)
 }
 
 func (entry *Entry) Panic(args ...interface{}) {
@@ -209,7 +209,7 @@ func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(fmt.Sprintf(format, args...))
 	}
-	Exit(1)
+	entry.Logger.handleExit(1)
 }
 
 func (entry *Entry) Panicf(format string, args ...interface{}) {
@@ -256,7 +256,7 @@ func (entry *Entry) Fatalln(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.Fatal(entry.sprintlnn(args...))
 	}
-	Exit(1)
+	entry.Logger.handleExit(1)
 }
 
 func (entry *Entry) Panicln(args ...interface{}) {

--- a/entry_test.go
+++ b/entry_test.go
@@ -32,6 +32,48 @@ func TestEntryWithError(t *testing.T) {
 
 }
 
+func TestEntryFatal(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter.Exit
+	entry := NewEntry(logger)
+
+	entry.Fatal("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+func TestEntryFatalf(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter.Exit
+	entry := NewEntry(logger)
+
+	entry.Fatalf("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+func TestEntryFatalln(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Exit = exiter.Exit
+	entry := NewEntry(logger)
+
+	entry.Fatalln("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
 func TestEntryPanicln(t *testing.T) {
 	errBoom := fmt.Errorf("boom time")
 

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,8 @@ type Logger struct {
 	Level Level
 	// Used to sync writing to the log. Locking is enabled by Default
 	mu MutexWrap
+	// Reusable empty entry
+	entryPool sync.Pool
 }
 
 type MutexWrap struct {
@@ -72,163 +74,229 @@ func New() *Logger {
 	}
 }
 
+func (logger *Logger) newEntry() *Entry {
+	entry, ok := logger.entryPool.Get().(*Entry)
+	if ok {
+		return entry
+	}
+	return NewEntry(logger)
+}
+
+func (logger *Logger) releaseEntry(entry *Entry) {
+	logger.entryPool.Put(entry)
+}
+
 // Adds a field to the log entry, note that it doesn't log until you call
 // Debug, Print, Info, Warn, Fatal or Panic. It only creates a log entry.
 // If you want multiple fields, use `WithFields`.
 func (logger *Logger) WithField(key string, value interface{}) *Entry {
-	return NewEntry(logger).WithField(key, value)
+	entry := logger.newEntry()
+	defer logger.releaseEntry(entry)
+	return entry.WithField(key, value)
 }
 
 // Adds a struct of fields to the log entry. All it does is call `WithField` for
 // each `Field`.
 func (logger *Logger) WithFields(fields Fields) *Entry {
-	return NewEntry(logger).WithFields(fields)
+	entry := logger.newEntry()
+	defer logger.releaseEntry(entry)
+	return entry.WithFields(fields)
 }
 
 // Add an error as single field to the log entry.  All it does is call
 // `WithError` for the given `error`.
 func (logger *Logger) WithError(err error) *Entry {
-	return NewEntry(logger).WithError(err)
+	entry := logger.newEntry()
+	defer logger.releaseEntry(entry)
+	return entry.WithError(err)
 }
 
 func (logger *Logger) Debugf(format string, args ...interface{}) {
 	if logger.Level >= DebugLevel {
-		NewEntry(logger).Debugf(format, args...)
+		entry := logger.newEntry()
+		entry.Debugf(format, args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Infof(format string, args ...interface{}) {
 	if logger.Level >= InfoLevel {
-		NewEntry(logger).Infof(format, args...)
+		entry := logger.newEntry()
+		entry.Infof(format, args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Printf(format string, args ...interface{}) {
-	NewEntry(logger).Printf(format, args...)
+	entry := logger.newEntry()
+	entry.Printf(format, args...)
+	logger.releaseEntry(entry)
 }
 
 func (logger *Logger) Warnf(format string, args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		NewEntry(logger).Warnf(format, args...)
+		entry := logger.newEntry()
+		entry.Warnf(format, args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Warningf(format string, args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		NewEntry(logger).Warnf(format, args...)
+		entry := logger.newEntry()
+		entry.Warnf(format, args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Errorf(format string, args ...interface{}) {
 	if logger.Level >= ErrorLevel {
-		NewEntry(logger).Errorf(format, args...)
+		entry := logger.newEntry()
+		entry.Errorf(format, args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Fatalf(format string, args ...interface{}) {
 	if logger.Level >= FatalLevel {
-		NewEntry(logger).Fatalf(format, args...)
+		entry := logger.newEntry()
+		entry.Fatalf(format, args...)
+		logger.releaseEntry(entry)
 	}
 	Exit(1)
 }
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
 	if logger.Level >= PanicLevel {
-		NewEntry(logger).Panicf(format, args...)
+		entry := logger.newEntry()
+		entry.Panicf(format, args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Debug(args ...interface{}) {
 	if logger.Level >= DebugLevel {
-		NewEntry(logger).Debug(args...)
+		entry := logger.newEntry()
+		entry.Debug(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Info(args ...interface{}) {
 	if logger.Level >= InfoLevel {
-		NewEntry(logger).Info(args...)
+		entry := logger.newEntry()
+		entry.Info(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Print(args ...interface{}) {
-	NewEntry(logger).Info(args...)
+	entry := logger.newEntry()
+	entry.Info(args...)
+	logger.releaseEntry(entry)
 }
 
 func (logger *Logger) Warn(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		NewEntry(logger).Warn(args...)
+		entry := logger.newEntry()
+		entry.Warn(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Warning(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		NewEntry(logger).Warn(args...)
+		entry := logger.newEntry()
+		entry.Warn(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Error(args ...interface{}) {
 	if logger.Level >= ErrorLevel {
-		NewEntry(logger).Error(args...)
+		entry := logger.newEntry()
+		entry.Error(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Fatal(args ...interface{}) {
 	if logger.Level >= FatalLevel {
-		NewEntry(logger).Fatal(args...)
+		entry := logger.newEntry()
+		entry.Fatal(args...)
+		logger.releaseEntry(entry)
 	}
 	Exit(1)
 }
 
 func (logger *Logger) Panic(args ...interface{}) {
 	if logger.Level >= PanicLevel {
-		NewEntry(logger).Panic(args...)
+		entry := logger.newEntry()
+		entry.Panic(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Debugln(args ...interface{}) {
 	if logger.Level >= DebugLevel {
-		NewEntry(logger).Debugln(args...)
+		entry := logger.newEntry()
+		entry.Debugln(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Infoln(args ...interface{}) {
 	if logger.Level >= InfoLevel {
-		NewEntry(logger).Infoln(args...)
+		entry := logger.newEntry()
+		entry.Infoln(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Println(args ...interface{}) {
-	NewEntry(logger).Println(args...)
+	entry := logger.newEntry()
+	entry.Println(args...)
+	logger.releaseEntry(entry)
 }
 
 func (logger *Logger) Warnln(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		NewEntry(logger).Warnln(args...)
+		entry := logger.newEntry()
+		entry.Warnln(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Warningln(args ...interface{}) {
 	if logger.Level >= WarnLevel {
-		NewEntry(logger).Warnln(args...)
+		entry := logger.newEntry()
+		entry.Warnln(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Errorln(args ...interface{}) {
 	if logger.Level >= ErrorLevel {
-		NewEntry(logger).Errorln(args...)
+		entry := logger.newEntry()
+		entry.Errorln(args...)
+		logger.releaseEntry(entry)
 	}
 }
 
 func (logger *Logger) Fatalln(args ...interface{}) {
 	if logger.Level >= FatalLevel {
-		NewEntry(logger).Fatalln(args...)
+		entry := logger.newEntry()
+		entry.Fatalln(args...)
+		logger.releaseEntry(entry)
 	}
 	Exit(1)
 }
 
 func (logger *Logger) Panicln(args ...interface{}) {
 	if logger.Level >= PanicLevel {
-		NewEntry(logger).Panicln(args...)
+		entry := logger.newEntry()
+		entry.Panicln(args...)
+		logger.releaseEntry(entry)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,11 @@ type Logger struct {
 	// to) `logrus.Info`, which allows Info(), Warn(), Error() and Fatal() to be
 	// logged. `logrus.Debug` is useful in
 	Level Level
+	// The function invoked by the Fatal() family of functions. The default is `os.Exit`.
+	// Keep in mind that invocation of any Fatal() function is expected to
+	// terminate execution. Replacing this with a function that does not terminate
+	// execution may lead to surprising results.
+	Exit func(int)
 	// Used to sync writing to the log. Locking is enabled by Default
 	mu MutexWrap
 	// Reusable empty entry
@@ -163,7 +168,7 @@ func (logger *Logger) Fatalf(format string, args ...interface{}) {
 		entry.Fatalf(format, args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
+	logger.handleExit(1)
 }
 
 func (logger *Logger) Panicf(format string, args ...interface{}) {
@@ -226,7 +231,7 @@ func (logger *Logger) Fatal(args ...interface{}) {
 		entry.Fatal(args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
+	logger.handleExit(1)
 }
 
 func (logger *Logger) Panic(args ...interface{}) {
@@ -289,7 +294,7 @@ func (logger *Logger) Fatalln(args ...interface{}) {
 		entry.Fatalln(args...)
 		logger.releaseEntry(entry)
 	}
-	Exit(1)
+	logger.handleExit(1)
 }
 
 func (logger *Logger) Panicln(args ...interface{}) {

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -22,12 +22,36 @@ func BenchmarkDummyLogger(b *testing.B) {
 	doLoggerBenchmark(b, nullf, &TextFormatter{DisableColors: true}, smallFields)
 }
 
+func BenchmarkDummyLoggerNoLock(b *testing.B) {
+	nullf, err := os.OpenFile("/dev/null", os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		b.Fatalf("%v", err)
+	}
+	defer nullf.Close()
+	doLoggerBenchmarkNoLock(b, nullf, &TextFormatter{DisableColors: true}, smallFields)
+}
+
 func doLoggerBenchmark(b *testing.B, out *os.File, formatter Formatter, fields Fields) {
 	logger := Logger{
 		Out:       out,
 		Level:     InfoLevel,
 		Formatter: formatter,
 	}
+	entry := logger.WithFields(fields)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			entry.Info("aaa")
+		}
+	})
+}
+
+func doLoggerBenchmarkNoLock(b *testing.B, out *os.File, formatter Formatter, fields Fields) {
+	logger := Logger{
+		Out:       out,
+		Level:     InfoLevel,
+		Formatter: formatter,
+	}
+	logger.SetNoLock()
 	entry := logger.WithFields(fields)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -1,0 +1,37 @@
+package logrus
+
+import (
+	"os"
+	"testing"
+)
+
+// smallFields is a small size data set for benchmarking
+var loggerFields = Fields{
+	"foo":   "bar",
+	"baz":   "qux",
+	"one":   "two",
+	"three": "four",
+}
+
+func BenchmarkDummyLogger(b *testing.B) {
+	nullf, err := os.OpenFile("/dev/null", os.O_WRONLY, 0666)
+	if err != nil {
+		b.Fatalf("%v", err)
+	}
+	defer nullf.Close()
+	doLoggerBenchmark(b, nullf, &TextFormatter{DisableColors: true}, smallFields)
+}
+
+func doLoggerBenchmark(b *testing.B, out *os.File, formatter Formatter, fields Fields) {
+	logger := Logger{
+		Out:       out,
+		Level:     InfoLevel,
+		Formatter: formatter,
+	}
+	entry := logger.WithFields(fields)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			entry.Info("aaa")
+		}
+	})
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,53 @@
+package logrus
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that logger.Fatal() exits even if log level set to set Panic.
+func TestFatal(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatal("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+// Test that logger.Fatalf() exits even if log level set to set Panic.
+func TestFatalf(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatalf("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}
+
+// Test that logger.Fatalln() exits even if log level set to set Panic.
+func TestFatalln(t *testing.T) {
+	assert := assert.New(t)
+
+	exiter := new(exiter)
+	logger := New()
+	logger.Out = &bytes.Buffer{}
+	logger.Level = PanicLevel
+	logger.Exit = exiter.Exit
+
+	logger.Fatalln("kaboom")
+
+	assert.Equal(1, exiter.exitCode)
+}

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -359,3 +359,11 @@ func TestLogrusInterface(t *testing.T) {
 	e := logger.WithField("another", "value")
 	fn(e)
 }
+
+type exiter struct {
+	exitCode int
+}
+
+func (e *exiter) Exit(exitCode int) {
+	e.exitCode = exitCode
+}

--- a/text_formatter.go
+++ b/text_formatter.go
@@ -57,6 +57,7 @@ type TextFormatter struct {
 }
 
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
+	var b *bytes.Buffer
 	var keys []string = make([]string, 0, len(entry.Data))
 	for k := range entry.Data {
 		keys = append(keys, k)
@@ -65,8 +66,11 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	if !f.DisableSorting {
 		sort.Strings(keys)
 	}
-
-	b := &bytes.Buffer{}
+	if entry.Buffer != nil {
+		b = entry.Buffer
+	} else {
+		b = &bytes.Buffer{}
+	}
 
 	prefixFieldClashes(entry.Data)
 


### PR DESCRIPTION
Adds the ability to replace the exit function called by logrus's `Fatal()` family. Tests can use this to replace the function with a stub that `panic`s or otherwise stores the exit call without killing the test run.

This does mean that libraries receiving a `Logger` will be able to circumvent the exit functionality of Fatal calls, but those libraries could already arbitrarily terminate the program, change the logger's output destination, and add hooks, so I don't think it's really a concern.

See https://github.com/Sirupsen/logrus/pull/375 for a PR that is trying to solve a similar problem (but still results in program termination).
